### PR TITLE
Fix metadata typos

### DIFF
--- a/balboa_worldwide_app.gemspec
+++ b/balboa_worldwide_app.gemspec
@@ -7,8 +7,8 @@ Gem::Specification.new do |s|
   s.version = BWA::VERSION
   s.platform = Gem::Platform::RUBY
   s.authors = ["Cody Cutrer"]
-  s.email = "cody@cutrer.com'"
-  s.homepage = "https://github.com/ccutrer/balboa_wordlwide_app"
+  s.email = "cody@cutrer.com"
+  s.homepage = "https://github.com/ccutrer/balboa_worldwide_app"
   s.summary = "Library for communication with Balboa Water Group's WiFi module or RS-485"
   s.license = "MIT"
   s.metadata = {


### PR DESCRIPTION
## Summary
- correct email string in gemspec
- fix typo in project homepage URL

## Testing
- `bundle exec rake` *(fails: Could not find dependencies; run `bundle install`)*

------
https://chatgpt.com/codex/tasks/task_e_68a703283ecc832db045f59f60e712ad